### PR TITLE
Added comments on all classes, methods, properties and interfaces and Enforced StyleCop rules

### DIFF
--- a/Marsop.Ephemeral/Exception/InvalidDurationException.cs
+++ b/Marsop.Ephemeral/Exception/InvalidDurationException.cs
@@ -1,19 +1,41 @@
-using System;
+// <copyright file="InvalidDurationException.cs" company="Marsop">
+//     https://github.com/marsop/ephemeral
+// </copyright>
 
 namespace Marsop.Ephemeral
 {
+    using System;
+
+    /// <summary>
+    /// Invalid interval duration exception
+    /// </summary>
     public class InvalidDurationException : ArgumentException
     {
-        public InvalidDurationException() { }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InvalidDurationException" /> class
+        /// </summary>
+        public InvalidDurationException()
+        {
+        }
 
-        public InvalidDurationException(string message) : base(message) { }
+        /// <inheritdoc cref="ArgumentException"/>
+        public InvalidDurationException(string message) : base(message)
+        {
+        }
 
-        public InvalidDurationException(string message, string paramName) : base(message, paramName) { }
+        /// <inheritdoc cref="ArgumentException"/>
+        public InvalidDurationException(string message, string paramName) : base(message, paramName)
+        {
+        }
 
-        public InvalidDurationException(string message, Exception innerException) : base(message, innerException) { }
+        /// <inheritdoc cref="ArgumentException"/>
+        public InvalidDurationException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
 
-        public InvalidDurationException(string message, string paramName, Exception innerException) :
-        base(message, paramName, innerException)
-        { }
+        /// <inheritdoc cref="ArgumentException"/>
+        public InvalidDurationException(string message, string paramName, Exception innerException) : base(message, paramName, innerException)
+        {
+        }
     }
 }

--- a/Marsop.Ephemeral/Exception/OverlapException.cs
+++ b/Marsop.Ephemeral/Exception/OverlapException.cs
@@ -1,19 +1,41 @@
-using System;
+// <copyright file="OverlapException.cs" company="Marsop">
+//     https://github.com/marsop/ephemeral
+// </copyright>
 
 namespace Marsop.Ephemeral
 {
+    using System;
+
+    /// <summary>
+    /// Overlap between intervals exception
+    /// </summary>
     public class OverlapException : ArgumentException
     {
-        public OverlapException() { }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OverlapException" /> class
+        /// </summary>
+        public OverlapException()
+        {
+        }
 
-        public OverlapException(string message) : base(message) { }
+        /// <inheritdoc cref="ArgumentException"/>
+        public OverlapException(string message) : base(message)
+        {
+        }
 
-        public OverlapException(string message, string paramName) : base(message, paramName) { }
+        /// <inheritdoc cref="ArgumentException"/>
+        public OverlapException(string message, string paramName) : base(message, paramName)
+        {
+        }
 
-        public OverlapException(string message, Exception innerException) : base(message, innerException) { }
+        /// <inheritdoc cref="ArgumentException"/>
+        public OverlapException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
 
-        public OverlapException(string message, string paramName, Exception innerException) :
-        base(message, paramName, innerException)
-        { }
+        /// <inheritdoc cref="ArgumentException"/>
+        public OverlapException(string message, string paramName, Exception innerException) : base(message, paramName, innerException)
+        {
+        }
     }
 }

--- a/Marsop.Ephemeral/Extensions/IntervalSetExtensions.cs
+++ b/Marsop.Ephemeral/Extensions/IntervalSetExtensions.cs
@@ -1,19 +1,34 @@
-using Optional.Unsafe;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+// <copyright file="IntervalSetExtensions.cs" company="Marsop">
+//     https://github.com/marsop/ephemeral
+// </copyright>
 
 namespace Marsop.Ephemeral.Extensions
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Optional.Unsafe;
+
+    /// <summary>
+    /// Extensions method for <see cref="IDisjointIntervalSet"/> instances
+    /// </summary>
     public static class IntervalSetExtensions
     {
-
         /// <summary>
         /// Checks if the timestamp is included in the interval set
         /// </summary>
+        /// <param name="set">the current <see cref="IDisjointIntervalSet"/> instance</param>
+        /// <param name="timestamp">the <see cref="DateTimeOffset"/> to check</param>
+        /// <returns><code>true</code> if the <see cref="DateTimeOffset"/> is covered by at least one interval in the set, <code>false</code> otherwise</returns>
         public static bool Covers(this IDisjointIntervalSet set, DateTimeOffset timestamp) =>
             set.Any(x => x.Covers(timestamp));
 
+        /// <summary>
+        /// Joins the given <see cref="IDisjointIntervalSet"/> with the current set
+        /// </summary>
+        /// <param name="set">the current <see cref="IDisjointIntervalSet"/> instance</param>
+        /// <param name="other">the <see cref="IDisjointIntervalSet"/> to join</param>
+        /// <returns>the joined <see cref="IDisjointIntervalSet"/></returns>
         public static IDisjointIntervalSet Join(this IDisjointIntervalSet set, IDisjointIntervalSet other)
         {
             var result = set.Consolidate();
@@ -21,6 +36,12 @@ namespace Marsop.Ephemeral.Extensions
             return result;
         }
 
+        /// <summary>
+        /// Joins the given <see cref="IInterval"/> with the current set
+        /// </summary>
+        /// <param name="set">the current <see cref="IDisjointIntervalSet"/> instance</param>
+        /// <param name="interval">the <see cref="IInterval"/> to join</param>
+        /// <returns>a new <see cref="IDisjointIntervalSet"/> with the joined intervals</returns>
         public static IDisjointIntervalSet Join(this IDisjointIntervalSet set, IInterval interval)
         {
             var groups = set.GroupBy(val => val.Intersects(interval)).ToDictionary(g => g.Key, g => g.ToList());
@@ -31,13 +52,21 @@ namespace Marsop.Ephemeral.Extensions
             var overlaps = groups.ContainsKey(true) ? groups[true] : new List<IInterval>();
             var newInterval = interval;
             foreach (var overlap in overlaps)
+            {
                 newInterval = Interval.Join(newInterval, overlap);
+            }
+
             result.Add(newInterval);
 
             return result;
         }
 
-
+        /// <summary>
+        /// Intersects the given <see cref="IInterval"/> with the current set
+        /// </summary>
+        /// <param name="set">the current <see cref="IDisjointIntervalSet"/> instance</param>
+        /// <param name="interval">the <see cref="IInterval"/> to intersect</param>
+        /// <returns>a new <see cref="IDisjointIntervalSet"/> with the intersected set</returns>
         public static IDisjointIntervalSet Intersect(this IDisjointIntervalSet set, IInterval interval)
         {
             var intersections = set
@@ -47,11 +76,11 @@ namespace Marsop.Ephemeral.Extensions
             return new DisjointIntervalSet(intersections);
         }
 
-
         /// <summary>
         /// Joins adjacent intervals.
         /// </summary>
-        /// <returns> new set with the minimum amount of intervals</returns>
+        /// <param name="set">the current <see cref="IDisjointIntervalSet"/> instance</param>
+        /// <returns>a new <see cref="IDisjointIntervalSet"/> with the minimum amount of intervals</returns>
         public static IDisjointIntervalSet Consolidate(this IDisjointIntervalSet set)
         {
             var result = new DisjointIntervalSet();

--- a/Marsop.Ephemeral/Implementation/DisjointIntervalSet.cs
+++ b/Marsop.Ephemeral/Implementation/DisjointIntervalSet.cs
@@ -1,88 +1,129 @@
-using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
-using Marsop.Ephemeral.Extensions;
+// <copyright file="DisjointIntervalSet.cs" company="Marsop">
+//     https://github.com/marsop/ephemeral
+// </copyright>
 
 namespace Marsop.Ephemeral
 {
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Marsop.Ephemeral.Extensions;
+
+    /// <summary>
+    /// Disjoint interval set class
+    /// </summary>
     public class DisjointIntervalSet : IDisjointIntervalSet
     {
-
+        /// <summary>
+        /// Internal sorted list of intervals
+        /// </summary>
         private SortedList<IInterval, IInterval> _intervals = new SortedList<IInterval, IInterval>(new IntervalStartComparer());
 
-        public DisjointIntervalSet() { }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DisjointIntervalSet" /> class
+        /// </summary>
+        public DisjointIntervalSet()
+        {
+        }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DisjointIntervalSet" /> class
+        /// </summary>
+        /// <param name="intervals">an <see cref="Array"/> of <see cref="IInterval"/> to initialize the set</param>
         public DisjointIntervalSet(params IInterval[] intervals)
         {
-            if (intervals != null && intervals.Count() > 0) {
-
+            if (intervals != null && intervals.Count() > 0)
+            {
                 foreach (var interval in intervals)
                 {
-                    Add(interval);
+                    this.Add(interval);
                 }
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DisjointIntervalSet" /> class
+        /// </summary>
+        /// <param name="intervals">an <see cref="IEnumerable{T}"/> of <see cref="IInterval"/> to initialize the set</param>
         public DisjointIntervalSet(IEnumerable<IInterval> intervals)
         {
             foreach (var interval in intervals)
             {
-                Add(interval);
+                this.Add(interval);
             }
         }
 
+        /// <inheritdoc cref="IDisjointIntervalSet.Start"/>
         public DateTimeOffset Start => this.Min(x => x.Start);
 
+        /// <inheritdoc cref="IDisjointIntervalSet.End"/>
         public DateTimeOffset End => this.Max(x => x.End);
 
+        /// <inheritdoc cref="IDisjointIntervalSet.AggregatedDuration"/>
         public TimeSpan AggregatedDuration => TimeSpan.FromTicks(this.Sum(x => x.Duration.Ticks));
 
-        // true if either there are no intervals or all can be smashed together into one
+        /// <inheritdoc cref="IDisjointIntervalSet.IsContiguous"/>
         public bool IsContiguous => this.Consolidate().Count < 2;
 
-        public int Count => _intervals.Count;
+        /// <inheritdoc cref="ICollection{Marsop.Ephemeral.IInterval}.Count"/>
+        public int Count => this._intervals.Count;
 
+        /// <inheritdoc cref="ICollection{Marsop.Ephemeral.IInterval}.IsReadOnly"/>
         public bool IsReadOnly => false;
 
-
+        /// <inheritdoc cref="IDisjointIntervalSet.StartIncluded"/>
         public bool StartIncluded { get; }
 
+        /// <inheritdoc cref="IDisjointIntervalSet.EndIncluded"/>
         public bool EndIncluded { get; }
-
+        
+        /// <inheritdoc cref="IList{T}.this[int]"/>
         public IInterval this[int index]
         {
-            get { return _intervals.Values[index]; }
-            set { _intervals.Values[index] = value; }
+            get { return this._intervals.Values[index]; }
+            set { this._intervals.Values[index] = value; }
         }
 
-        public int IndexOf(IInterval item) => _intervals.Values.IndexOf(item);
+        /// <inheritdoc cref="IList{T}.IndexOf"/>
+        public int IndexOf(IInterval item) => this._intervals.Values.IndexOf(item);
 
+        /// <inheritdoc cref="IList{T}.Insert"/>
         public void Insert(int index, IInterval item)
         {
             throw new NotSupportedException("The Set is always ordered, please use Add()");
         }
 
-        public void RemoveAt(int index) => _intervals.RemoveAt(index);
+        /// <inheritdoc cref="IList{T}.RemoveAt"/>
+        public void RemoveAt(int index) => this._intervals.RemoveAt(index);
 
+        /// <inheritdoc cref="ICollection{T}.Add"/>
         public void Add(IInterval item)
         {
             if (this.Any(x => x.Intersects(item)))
+            {
                 throw new OverlapException(nameof(item));
+            }
 
-            _intervals.Add(item, item);
+            this._intervals.Add(item, item);
         }
 
-        public void Clear() => _intervals.Clear();
+        /// <inheritdoc cref="ICollection{T}.Clear"/>
+        public void Clear() => this._intervals.Clear();
 
-        public bool Contains(IInterval item) => _intervals.ContainsKey(item);
+        /// <inheritdoc cref="ICollection{T}.Contains"/>
+        public bool Contains(IInterval item) => this._intervals.ContainsKey(item);
 
-        public void CopyTo(IInterval[] array, int arrayIndex) => _intervals.Values.CopyTo(array, arrayIndex);
+        /// <inheritdoc cref="ICollection{T}.CopyTo"/>
+        public void CopyTo(IInterval[] array, int arrayIndex) => this._intervals.Values.CopyTo(array, arrayIndex);
 
-        public bool Remove(IInterval item) => _intervals.Remove(item);
+        /// <inheritdoc cref="ICollection{T}.Remove"/>
+        public bool Remove(IInterval item) => this._intervals.Remove(item);
 
-        public IEnumerator<IInterval> GetEnumerator() => _intervals.Values.GetEnumerator();
+        /// <inheritdoc cref="IEnumerable{T}.GetEnumerator"/>
+        public IEnumerator<IInterval> GetEnumerator() => this._intervals.Values.GetEnumerator();
 
-        IEnumerator IEnumerable.GetEnumerator() => _intervals.Values.GetEnumerator();
+        /// <inheritdoc cref="IEnumerable.GetEnumerator"/>
+        IEnumerator IEnumerable.GetEnumerator() => this._intervals.Values.GetEnumerator();
     }
 }

--- a/Marsop.Ephemeral/Implementation/IntervalStartComparer.cs
+++ b/Marsop.Ephemeral/Implementation/IntervalStartComparer.cs
@@ -1,23 +1,37 @@
-using System;
-using System.Collections.Generic;
+// <copyright file="IntervalStartComparer.cs" company="Marsop">
+//     https://github.com/marsop/ephemeral
+// </copyright>
 
 namespace Marsop.Ephemeral
 {
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Interval starting point comparer class
+    /// </summary>
     public class IntervalStartComparer : IComparer<IInterval>
     {
+        /// <inheritdoc cref="IComparer{T}.Compare"/>
         public int Compare(IInterval x, IInterval y)
         {
             var startComparison = x.Start.CompareTo(y.Start);
             if (startComparison != 0)
+            {
                 return startComparison;
+            }
 
             if (x.StartIncluded && !y.StartIncluded)
+            {
                 return -1;
-
+            }
             else if (!x.StartIncluded && y.StartIncluded)
+            {
                 return 1;
-
-            else return 0;
+            }
+            else
+            {
+                return 0;
+            }
         }
     }
 }

--- a/Marsop.Ephemeral/Interfaces/IDisjointIntervalSet.cs
+++ b/Marsop.Ephemeral/Interfaces/IDisjointIntervalSet.cs
@@ -1,40 +1,50 @@
-using System;
-using System.Collections.Generic;
-using Marsop.Ephemeral.Extensions;
+// <copyright file="IDisjointIntervalSet.cs" company="Marsop">
+//     https://github.com/marsop/ephemeral
+// </copyright>
 
 namespace Marsop.Ephemeral
 {
+    using System;
+    using System.Collections.Generic;
+    using Marsop.Ephemeral.Extensions;
+
     /// <summary>
     /// Collection of disjoint IIntervals
     /// </summary>
     public interface IDisjointIntervalSet : IList<IInterval>
     {
         /// <summary>
-        /// True if all the contained intervals are contiguous or if empty
+        /// Gets a value indicating whether all the contained intervals are contiguous or the set is empty
         /// </summary>
         bool IsContiguous { get; }
 
         /// <summary>
-        /// Sum of durations of each of the enclosed intervals 
+        /// Gets the sum of durations of each of the enclosed intervals 
         /// </summary>
         TimeSpan AggregatedDuration { get; }
 
         /// <summary>
-        /// Start of the earliest contained Interval
+        /// Gets the Start of the earliest contained Interval
         /// </summary>
         DateTimeOffset Start { get; }
 
         /// <summary>
-        /// End of the latest contained Interval
+        /// Gets the end of the latest contained Interval
         /// </summary>
         DateTimeOffset End { get; }
 
+        /// <summary>
+        /// Gets a value indicating whether the Start is included
+        /// </summary>
         bool StartIncluded { get; }
 
+        /// <summary>
+        /// Gets a value indicating whether the End is included
+        /// </summary>
         bool EndIncluded { get; }
 
         /// <summary>
-        /// Minimum interval that contais all the intervals of the set.
+        /// Gets the minimum interval that contains all the intervals of the set.
         /// </summary>
         /// <returns></returns>
         IInterval GetBoundingInterval() => new Interval(Start, End, this.Covers(Start), this.Covers(End));

--- a/Marsop.Ephemeral/Interfaces/IInterval.cs
+++ b/Marsop.Ephemeral/Interfaces/IInterval.cs
@@ -1,36 +1,39 @@
-using System;
+// <copyright file="IInterval.cs" company="Marsop">
+//     https://github.com/marsop/ephemeral
+// </copyright>
 
 namespace Marsop.Ephemeral
 {
+    using System;
+
     /// <summary>
     /// Interface for classes implementing an interval
     /// </summary>
     public interface IInterval
     {
         /// <summary>
-        /// starting point of the interval
+        /// Gets the starting point of the interval
         /// </summary>
         DateTimeOffset Start { get; }
 
         /// <summary>
-        /// indicates if the start timestamp is included in the interval
+        /// Gets a value indicating whether the start timestamp is included in the interval
         /// </summary>
         bool StartIncluded { get; }
 
         /// <summary>
-        /// final point of the interval
+        /// Gets the final point of the interval
         /// </summary>
         DateTimeOffset End { get; }
 
         /// <summary>
-        /// indicates if the end timestamp is included in the interval
+        /// Gets a value indicating whether the end timestamp is included in the interval
         /// </summary>
         bool EndIncluded { get; }
 
         /// <summary>
-        /// gets the difference between start and end as timestamp
+        /// Gets the difference between start and end as <see cref="TimeSpan"/>
         /// </summary>
-        public TimeSpan Duration => End - Start;
-
+        public TimeSpan Duration => this.End - this.Start;
     }
 }

--- a/Marsop.Ephemeral/Interfaces/ITimestamped.cs
+++ b/Marsop.Ephemeral/Interfaces/ITimestamped.cs
@@ -1,12 +1,19 @@
-using System;
+// <copyright file="ITimestamped.cs" company="Marsop">
+//     https://github.com/marsop/ephemeral
+// </copyright>
 
 namespace Marsop.Ephemeral
 {
+    using System;
+    
     /// <summary>
     /// Simple interface for objects with time information
     /// </summary>
     public interface ITimestamped
     {
+        /// <summary>
+        /// Gets the timestamp
+        /// </summary>
         DateTimeOffset Timestamp { get; }
     }
 }


### PR DESCRIPTION
+ Added comments on all classes, methods, properties and interfaces
+ Enforced StyleCop rules on source (except SA1309 : CSharp.Naming : Field names must not start with an underscore. in Implementation\DisjointIntervalSet.cs:21)

(because I like too the underscore for private fields and I usually remove SA1309 from StyleCop rules)