### PR TITLE
🧹 Remove unnecessary private constructors from default length operators

### DIFF
--- a/Marsop.Ephemeral.Net6/Temporal/DateOnlyDaysLengthOperator.cs
+++ b/Marsop.Ephemeral.Net6/Temporal/DateOnlyDaysLengthOperator.cs
@@ -9,8 +9,6 @@ public class DateOnlyDaysLengthOperator : ILengthOperator<DateOnly, int>
 {
     public static DateOnlyDaysLengthOperator Instance { get; } = new DateOnlyDaysLengthOperator();
 
-    private DateOnlyDaysLengthOperator() { }
-
     public DateOnly Apply(DateOnly boundary, int length) => boundary.AddDays(length);
 
     public int Measure(IBasicInterval<DateOnly> interval)

--- a/Marsop.Ephemeral.Net6/Temporal/TimeOnlyTimeSpanLengthOperator.cs
+++ b/Marsop.Ephemeral.Net6/Temporal/TimeOnlyTimeSpanLengthOperator.cs
@@ -7,8 +7,6 @@ namespace Marsop.Ephemeral.Net6.Temporal;
 /// </summary>
 public class TimeOnlyTimeSpanLengthOperator : ILengthOperator<TimeOnly, TimeSpan>
 {
-    private TimeOnlyTimeSpanLengthOperator() { }
-
     public static TimeOnlyTimeSpanLengthOperator Instance { get; } = new TimeOnlyTimeSpanLengthOperator();
 
     public TimeOnly Apply(TimeOnly boundary, TimeSpan length) => boundary.Add(length);

--- a/Marsop.Ephemeral/Numerics/DoubleStandardLengthOperator.cs
+++ b/Marsop.Ephemeral/Numerics/DoubleStandardLengthOperator.cs
@@ -9,8 +9,6 @@ public sealed class DoubleDefaultLengthOperator :
 
     public static ILengthOperator<double, double> Instance => _instance;
 
-    private DoubleDefaultLengthOperator() { }
-
     public double Apply(double boundary, double length) => boundary + length;
 
     public double Measure(IBasicInterval<double> interval) => interval.End - interval.Start;

--- a/Marsop.Ephemeral/Numerics/IntStandardLengthOperator.cs
+++ b/Marsop.Ephemeral/Numerics/IntStandardLengthOperator.cs
@@ -9,8 +9,6 @@ public sealed class IntDefaultLengthOperator :
 
     public static ILengthOperator<int, int> Instance => _instance;
 
-    private IntDefaultLengthOperator() { }
-
     public int Apply(int boundary, int length) => boundary + length;
 
     public int Measure(IBasicInterval<int> interval) => interval.End - interval.Start;

--- a/Marsop.Ephemeral/Temporal/DateTimeOffsetStandardLengthOperator.cs
+++ b/Marsop.Ephemeral/Temporal/DateTimeOffsetStandardLengthOperator.cs
@@ -10,8 +10,6 @@ public sealed class DateTimeOffsetTimeSpanLengthOperator :
 
     public static ILengthOperator<DateTimeOffset, TimeSpan> Instance => _instance;
 
-    private DateTimeOffsetTimeSpanLengthOperator() { }
-
     public DateTimeOffset Apply(DateTimeOffset boundary, TimeSpan length) => boundary.Add(length);
 
     public TimeSpan Measure(IBasicInterval<DateTimeOffset> interval) => interval.End - interval.Start;


### PR DESCRIPTION
🎯 **What:** Removed empty private parameterless constructors from multiple singleton-like default length operator classes (`IntDefaultLengthOperator`, `DoubleDefaultLengthOperator`, `DateTimeOffsetTimeSpanLengthOperator`, `TimeOnlyTimeSpanLengthOperator`, `DateOnlyDaysLengthOperator`).
💡 **Why:** Empty private constructors used for basic singletons are clear targets for removal if they are not enforcing specific constraints. Removing them improves code readability and maintainability.
✅ **Verification:** Ran `dotnet build` and `dotnet test`. The project builds successfully and all 65 tests passed without issues.
✨ **Result:** A cleaner codebase with less boilerplate code.

---
*PR created automatically by Jules for task [16873515901587996144](https://jules.google.com/task/16873515901587996144) started by @marsop*