### PR TITLE
🧹 Code Health: Remove excessive blank lines in BasicIntervalExtensions

### DIFF
--- a/Marsop.Ephemeral/Core/Extensions/BasicIntervalExtensions.cs
+++ b/Marsop.Ephemeral/Core/Extensions/BasicIntervalExtensions.cs
@@ -146,9 +146,6 @@ public static class BasicIntervalExtensions
         return new BasicInterval<TBoundary>(interval.Start, newEnd, interval.StartIncluded, interval.EndIncluded);
     }
 
-    
-    
-    
     /// <summary>
     /// Checks if the interval covers the given interval
     /// </summary>


### PR DESCRIPTION
🎯 **What:** Removed excessive blank lines in `Marsop.Ephemeral/Core/Extensions/BasicIntervalExtensions.cs` around line 149 before the `Covers` method.
💡 **Why:** This improves the maintainability and readability of the codebase by adhering to standard C# formatting conventions.
✅ **Verification:** Verified via `cat` and successfully ran `dotnet test`. Code review confirmed it was safe and correct.
✨ **Result:** Cleaned up excessive spacing between methods.

---
*PR created automatically by Jules for task [17787359594827503242](https://jules.google.com/task/17787359594827503242) started by @marsop*