### PR TITLE
🧹 [Code Health] Replace inefficient Count() check with Any()

### DIFF
--- a/Marsop.Ephemeral/Core/Implementation/DisjointIntervalSet.cs
+++ b/Marsop.Ephemeral/Core/Implementation/DisjointIntervalSet.cs
@@ -52,7 +52,7 @@ public class DisjointIntervalSet<TBoundary, TLength> :
             throw new ArgumentNullException(nameof(intervals));
         }
 
-        if (intervals?.Count() > 0)
+        if (intervals.Any())
         {
             foreach (var interval in intervals)
             {


### PR DESCRIPTION
🎯 **What:** Replaced `intervals?.Count() > 0` with `intervals.Any()` in `Marsop.Ephemeral/Core/Implementation/DisjointIntervalSet.cs`.

💡 **Why:** `Count()` requires iterating the entire collection (if not an `ICollection`), whereas `Any()` returns as soon as it encounters the first element, which is more performant. Additionally, `intervals` is guaranteed to be non-null at this point because a check is made right above it, so the null conditional operator `?.` was safely removed.

✅ **Verification:** Verified the fix by running the test suite via `dotnet test`, with all tests passing successfully.

✨ **Result:** Improved LINQ performance and code clarity.

---
*PR created automatically by Jules for task [3621772441696351135](https://jules.google.com/task/3621772441696351135) started by @marsop*