### PR TITLE
Restore private constructors to enforce singleton pattern

### DIFF
--- a/Marsop.Ephemeral.Net6/Temporal/DateOnlyDaysLengthOperator.cs
+++ b/Marsop.Ephemeral.Net6/Temporal/DateOnlyDaysLengthOperator.cs
@@ -9,6 +9,8 @@ public class DateOnlyDaysLengthOperator : ILengthOperator<DateOnly, int>
 {
     public static DateOnlyDaysLengthOperator Instance { get; } = new DateOnlyDaysLengthOperator();
 
+    private DateOnlyDaysLengthOperator() { }
+
     public DateOnly Apply(DateOnly boundary, int length) => boundary.AddDays(length);
 
     public int Measure(IBasicInterval<DateOnly> interval)

--- a/Marsop.Ephemeral.Net6/Temporal/TimeOnlyTimeSpanLengthOperator.cs
+++ b/Marsop.Ephemeral.Net6/Temporal/TimeOnlyTimeSpanLengthOperator.cs
@@ -7,6 +7,8 @@ namespace Marsop.Ephemeral.Net6.Temporal;
 /// </summary>
 public class TimeOnlyTimeSpanLengthOperator : ILengthOperator<TimeOnly, TimeSpan>
 {
+    private TimeOnlyTimeSpanLengthOperator() { }
+
     public static TimeOnlyTimeSpanLengthOperator Instance { get; } = new TimeOnlyTimeSpanLengthOperator();
 
     public TimeOnly Apply(TimeOnly boundary, TimeSpan length) => boundary.Add(length);

--- a/Marsop.Ephemeral/Numerics/DoubleStandardLengthOperator.cs
+++ b/Marsop.Ephemeral/Numerics/DoubleStandardLengthOperator.cs
@@ -9,6 +9,8 @@ public sealed class DoubleDefaultLengthOperator :
 
     public static ILengthOperator<double, double> Instance => _instance;
 
+    private DoubleDefaultLengthOperator() { }
+
     public double Apply(double boundary, double length) => boundary + length;
 
     public double Measure(IBasicInterval<double> interval) => interval.End - interval.Start;

--- a/Marsop.Ephemeral/Numerics/IntStandardLengthOperator.cs
+++ b/Marsop.Ephemeral/Numerics/IntStandardLengthOperator.cs
@@ -9,6 +9,8 @@ public sealed class IntDefaultLengthOperator :
 
     public static ILengthOperator<int, int> Instance => _instance;
 
+    private IntDefaultLengthOperator() { }
+
     public int Apply(int boundary, int length) => boundary + length;
 
     public int Measure(IBasicInterval<int> interval) => interval.End - interval.Start;

--- a/Marsop.Ephemeral/Temporal/DateTimeOffsetStandardLengthOperator.cs
+++ b/Marsop.Ephemeral/Temporal/DateTimeOffsetStandardLengthOperator.cs
@@ -10,6 +10,8 @@ public sealed class DateTimeOffsetTimeSpanLengthOperator :
 
     public static ILengthOperator<DateTimeOffset, TimeSpan> Instance => _instance;
 
+    private DateTimeOffsetTimeSpanLengthOperator() { }
+
     public DateTimeOffset Apply(DateTimeOffset boundary, TimeSpan length) => boundary.Add(length);
 
     public TimeSpan Measure(IBasicInterval<DateTimeOffset> interval) => interval.End - interval.Start;


### PR DESCRIPTION
The private constructors have been restored to properly enforce the singleton pattern on these operator classes.