### PR TITLE
Update to .NET 10

### DIFF
--- a/.github/workflows/dotnet-10.yml
+++ b/.github/workflows/dotnet-10.yml
@@ -1,4 +1,4 @@
-name: .NET 8
+name: .NET 10
 
 on:
   push:
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET 8
+    - name: Setup .NET 10
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
 
     - name: Install dependencies
       run: dotnet restore

--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Restore dependencies
         run: dotnet restore Marsop.Ephemeral/Marsop.Ephemeral.csproj

--- a/Marsop.Ephemeral.Net6.Tests/Marsop.Ephemeral.Net6.Tests.csproj
+++ b/Marsop.Ephemeral.Net6.Tests/Marsop.Ephemeral.Net6.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/Marsop.Ephemeral.Tests/Marsop.Ephemeral.Tests.csproj
+++ b/Marsop.Ephemeral.Tests/Marsop.Ephemeral.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyVersion>0.1.8.0</AssemblyVersion>
     <FileVersion>0.1.8.0</FileVersion>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "10.0.103",
     "rollForward": "latestMajor"
   }
 }

--- a/notebooks/global.json
+++ b/notebooks/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.300",
+    "version": "10.0.103",
     "rollForward": "latestMajor"
   }
 }


### PR DESCRIPTION
Updates the relevant projects, SDK versions, and GitHub Action workflows to .NET 10, while keeping the main libraries targeting .NET 6 and .NET Standard 2.1 respectively for compatibility. All test projects now target `net10.0`.

---
*PR created automatically by Jules for task [9042388978246586900](https://jules.google.com/task/9042388978246586900) started by @marsop*