### PR TITLE
Update Marsop.Ephemeral to target .NET Standard 2.0

### DIFF
--- a/Marsop.Ephemeral/Marsop.Ephemeral.csproj
+++ b/Marsop.Ephemeral/Marsop.Ephemeral.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <VersionPrefix>0.2.0</VersionPrefix>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
 
     <PackageId>Ephemeral</PackageId>
     <PackageTags>Time;Timestamps;Intervals</PackageTags>

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 C# Library to handle intervals (composite start and end)
 
+- Targets `.NET Standard 2.0` for wide compatibility.
 - Support for generic types in intervals (e.g. `DateTimeOffset`, `int`, `double`).
 - Support for open and closed intervals.
 - Support for common operations like Covers(), Intersect(), Join(), etc. via extension methods.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,7 @@
 
 C# Library to handle intervals (composite start and end)
 
+- Targets `.NET Standard 2.0` for wide compatibility.
 - Support for generic types in intervals (e.g. `DateTimeOffset`, `int`, `double`).
 - Support for open and closed intervals.
 - Support for common operations like Covers(), Intersect(), Join(), etc. via extension methods.


### PR DESCRIPTION
Update `Marsop.Ephemeral` target framework to `netstandard2.0` to broaden compatibility, and document this change in `README.md` and `docs/index.md`.

---
*PR created automatically by Jules for task [9046056484555084929](https://jules.google.com/task/9046056484555084929) started by @marsop*