### PR TITLE
chore: bump beta version to beta.7

### DIFF
--- a/Marsop.Ephemeral.Net6/Marsop.Ephemeral.Net6.csproj
+++ b/Marsop.Ephemeral.Net6/Marsop.Ephemeral.Net6.csproj
@@ -20,7 +20,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     
-    <Version>$(VersionPrefix)-beta.6</Version>
+    <Version>$(VersionPrefix)-beta.7</Version>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     

--- a/Marsop.Ephemeral/Marsop.Ephemeral.csproj
+++ b/Marsop.Ephemeral/Marsop.Ephemeral.csproj
@@ -20,7 +20,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 
-    <Version>$(VersionPrefix)-beta.6</Version>
+    <Version>$(VersionPrefix)-beta.7</Version>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     


### PR DESCRIPTION
Bumps the package version in `Marsop.Ephemeral` and `Marsop.Ephemeral.Net6` from `beta.6` to `beta.7` to trigger a redeploy to NuGet.

---
*PR created automatically by Jules for task [9973542530857098134](https://jules.google.com/task/9973542530857098134) started by @marsop*