### PR TITLE
Add XML documentation for numerics and temporal

### DIFF
--- a/Marsop.Ephemeral.Net6/Marsop.Ephemeral.Net6.csproj
+++ b/Marsop.Ephemeral.Net6/Marsop.Ephemeral.Net6.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <TargetFramework>net6.0</TargetFramework>
 
     <PackageId>Ephemeral.Net6</PackageId>

--- a/Marsop.Ephemeral.Net6/Marsop.Ephemeral.Net6.csproj
+++ b/Marsop.Ephemeral.Net6/Marsop.Ephemeral.Net6.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
     <TargetFramework>net6.0</TargetFramework>
 
     <PackageId>Ephemeral.Net6</PackageId>

--- a/Marsop.Ephemeral.Net6/Marsop.Ephemeral.Net6.csproj
+++ b/Marsop.Ephemeral.Net6/Marsop.Ephemeral.Net6.csproj
@@ -19,6 +19,7 @@
 
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     
     <Version>$(VersionPrefix)-beta.6</Version>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>

--- a/Marsop.Ephemeral.Net6/Marsop.Ephemeral.Net6.csproj
+++ b/Marsop.Ephemeral.Net6/Marsop.Ephemeral.Net6.csproj
@@ -21,7 +21,7 @@
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     
-    <Version>$(VersionPrefix)-beta.6</Version>
+    <Version>$(VersionPrefix)-beta.7</Version>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     

--- a/Marsop.Ephemeral.Net6/Temporal/DateOnlyDaysLengthOperator.cs
+++ b/Marsop.Ephemeral.Net6/Temporal/DateOnlyDaysLengthOperator.cs
@@ -7,6 +7,9 @@ namespace Marsop.Ephemeral.Net6.Temporal;
 /// </summary>
 public sealed class DateOnlyDaysLengthOperator : ILengthOperator<DateOnly, int>
 {
+    /// <summary>
+    /// Gets the singleton instance of the <see cref="DateOnlyDaysLengthOperator"/>.
+    /// </summary>
     public static DateOnlyDaysLengthOperator Instance { get; } = new DateOnlyDaysLengthOperator();
 
     private DateOnlyDaysLengthOperator()
@@ -14,12 +17,15 @@ public sealed class DateOnlyDaysLengthOperator : ILengthOperator<DateOnly, int>
         // Private constructor to prevent external instantiation and enforce the singleton pattern.
     }
 
+    /// <inheritdoc/>
     public DateOnly Apply(DateOnly boundary, int length) => boundary.AddDays(length);
 
+    /// <inheritdoc/>
     public int Measure(IBasicInterval<DateOnly> interval)
     {
         return (interval.End.ToDateTime(TimeOnly.MinValue) - interval.Start.ToDateTime(TimeOnly.MinValue)).Days;
     }
 
+    /// <inheritdoc/>
     public int Zero() => 0;
 }

--- a/Marsop.Ephemeral.Net6/Temporal/DateOnlyInterval.cs
+++ b/Marsop.Ephemeral.Net6/Temporal/DateOnlyInterval.cs
@@ -2,23 +2,50 @@ using Marsop.Ephemeral.Core;
 
 namespace Marsop.Ephemeral.Net6.Temporal;
 
+/// <summary>
+/// Represents a temporal interval defined by <see cref="DateOnly"/> boundaries and measured in days (<see cref="int"/>).
+/// </summary>
 public record DateOnlyInterval : FullInterval<DateOnly, int>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DateOnlyInterval"/> class.
+    /// </summary>
+    /// <param name="start">The starting boundary.</param>
+    /// <param name="end">The ending boundary.</param>
+    /// <param name="startIncluded">A flag indicating whether the starting point is included.</param>
+    /// <param name="endIncluded">A flag indicating whether the ending point is included.</param>
     public DateOnlyInterval(DateOnly start, DateOnly end, bool startIncluded, bool endIncluded) :
         base(start, end, startIncluded, endIncluded)
     {
     }
 
+    /// <inheritdoc/>
     public override ILengthOperator<DateOnly, int> Operator =>
         DateOnlyDaysLengthOperator.Instance;
 
+    /// <inheritdoc cref="object.ToString"/>
     public override string ToString() => base.ToString();
 
+    /// <summary>
+    /// Creates a closed date-only interval (both start and end are included).
+    /// </summary>
+    /// <param name="start">The starting boundary.</param>
+    /// <param name="end">The ending boundary.</param>
+    /// <returns>A new <see cref="DateOnlyInterval"/> with both boundaries included.</returns>
     public new static DateOnlyInterval CreateClosed(DateOnly start, DateOnly end) => new(start, end, true, true);
 
+    /// <summary>
+    /// Creates an open date-only interval (neither start nor end are included).
+    /// </summary>
+    /// <param name="start">The starting boundary.</param>
+    /// <param name="end">The ending boundary.</param>
+    /// <returns>A new <see cref="DateOnlyInterval"/> with neither boundary included.</returns>
     public new static DateOnlyInterval CreateOpen(DateOnly start, DateOnly end) => new(start, end, false, false);
 
+    /// <summary>
+    /// Creates a date-only interval representing a single point (start and end are the same and included).
+    /// </summary>
+    /// <param name="boundary">The boundary value for the point.</param>
+    /// <returns>A new <see cref="DateOnlyInterval"/> representing a single point.</returns>
     public new static DateOnlyInterval CreatePoint(DateOnly boundary) => CreateClosed(boundary, boundary);
-
-
 }

--- a/Marsop.Ephemeral.Net6/Temporal/TimeOnlyInterval.cs
+++ b/Marsop.Ephemeral.Net6/Temporal/TimeOnlyInterval.cs
@@ -2,21 +2,50 @@ using Marsop.Ephemeral.Core;
 
 namespace Marsop.Ephemeral.Net6.Temporal;
 
+/// <summary>
+/// Represents a temporal interval defined by <see cref="TimeOnly"/> boundaries and measured in <see cref="TimeSpan"/>.
+/// </summary>
 public record TimeOnlyInterval : FullInterval<TimeOnly, TimeSpan>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TimeOnlyInterval"/> class.
+    /// </summary>
+    /// <param name="start">The starting boundary.</param>
+    /// <param name="end">The ending boundary.</param>
+    /// <param name="startIncluded">A flag indicating whether the starting point is included.</param>
+    /// <param name="endIncluded">A flag indicating whether the ending point is included.</param>
     public TimeOnlyInterval(TimeOnly start, TimeOnly end, bool startIncluded, bool endIncluded) :
         base(start, end, startIncluded, endIncluded)
     {
     }
 
+    /// <inheritdoc/>
     public override ILengthOperator<TimeOnly, TimeSpan> Operator =>
         TimeOnlyTimeSpanLengthOperator.Instance;
 
+    /// <inheritdoc cref="object.ToString"/>
     public override string ToString() => base.ToString();
 
+    /// <summary>
+    /// Creates a closed time-only interval (both start and end are included).
+    /// </summary>
+    /// <param name="start">The starting boundary.</param>
+    /// <param name="end">The ending boundary.</param>
+    /// <returns>A new <see cref="TimeOnlyInterval"/> with both boundaries included.</returns>
     public new static TimeOnlyInterval CreateClosed(TimeOnly start, TimeOnly end) => new(start, end, true, true);
 
+    /// <summary>
+    /// Creates an open time-only interval (neither start nor end are included).
+    /// </summary>
+    /// <param name="start">The starting boundary.</param>
+    /// <param name="end">The ending boundary.</param>
+    /// <returns>A new <see cref="TimeOnlyInterval"/> with neither boundary included.</returns>
     public new static TimeOnlyInterval CreateOpen(TimeOnly start, TimeOnly end) => new(start, end, false, false);
 
+    /// <summary>
+    /// Creates a time-only interval representing a single point (start and end are the same and included).
+    /// </summary>
+    /// <param name="boundary">The boundary value for the point.</param>
+    /// <returns>A new <see cref="TimeOnlyInterval"/> representing a single point.</returns>
     public new static TimeOnlyInterval CreatePoint(TimeOnly boundary) => CreateClosed(boundary, boundary);
 }

--- a/Marsop.Ephemeral.Net6/Temporal/TimeOnlyTimeSpanLengthOperator.cs
+++ b/Marsop.Ephemeral.Net6/Temporal/TimeOnlyTimeSpanLengthOperator.cs
@@ -12,11 +12,17 @@ public sealed class TimeOnlyTimeSpanLengthOperator : ILengthOperator<TimeOnly, T
         // Private constructor to prevent external instantiation and enforce the singleton pattern.
     }
 
+    /// <summary>
+    /// Gets the singleton instance of the <see cref="TimeOnlyTimeSpanLengthOperator"/>.
+    /// </summary>
     public static TimeOnlyTimeSpanLengthOperator Instance { get; } = new TimeOnlyTimeSpanLengthOperator();
 
+    /// <inheritdoc/>
     public TimeOnly Apply(TimeOnly boundary, TimeSpan length) => boundary.Add(length);
 
+    /// <inheritdoc/>
     public TimeSpan Measure(IBasicInterval<TimeOnly> interval) => interval.End - interval.Start;
 
+    /// <inheritdoc/>
     public TimeSpan Zero() => TimeSpan.Zero;
 }

--- a/Marsop.Ephemeral/Marsop.Ephemeral.csproj
+++ b/Marsop.Ephemeral/Marsop.Ephemeral.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
     <TargetFramework>netstandard2.0</TargetFramework>
 
     <PackageId>Ephemeral</PackageId>

--- a/Marsop.Ephemeral/Marsop.Ephemeral.csproj
+++ b/Marsop.Ephemeral/Marsop.Ephemeral.csproj
@@ -19,6 +19,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <Version>$(VersionPrefix)-beta.6</Version>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>

--- a/Marsop.Ephemeral/Marsop.Ephemeral.csproj
+++ b/Marsop.Ephemeral/Marsop.Ephemeral.csproj
@@ -21,7 +21,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-    <Version>$(VersionPrefix)-beta.6</Version>
+    <Version>$(VersionPrefix)-beta.7</Version>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     

--- a/Marsop.Ephemeral/Marsop.Ephemeral.csproj
+++ b/Marsop.Ephemeral/Marsop.Ephemeral.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <TargetFramework>netstandard2.0</TargetFramework>
 
     <PackageId>Ephemeral</PackageId>

--- a/Marsop.Ephemeral/Numerics/DoubleInterval.cs
+++ b/Marsop.Ephemeral/Numerics/DoubleInterval.cs
@@ -2,21 +2,50 @@ using Marsop.Ephemeral.Core;
 
 namespace Marsop.Ephemeral.Numerics;
 
+/// <summary>
+/// Represents an interval of <see cref="double"/> values.
+/// </summary>
 public record DoubleInterval :
     FullInterval<double, double>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DoubleInterval"/> class.
+    /// </summary>
+    /// <param name="start">The starting boundary of the interval.</param>
+    /// <param name="end">The ending boundary of the interval.</param>
+    /// <param name="startIncluded">A flag indicating whether the starting point is included. Defaults to true.</param>
+    /// <param name="endIncluded">A flag indicating whether the ending point is included. Defaults to true.</param>
     public DoubleInterval(double start, double end, bool startIncluded = true, bool endIncluded = true)
         : base(start, end, startIncluded, endIncluded)
     {
     }
 
+    /// <inheritdoc/>
     public override ILengthOperator<double, double> Operator => DoubleDefaultLengthOperator.Instance;
 
+    /// <inheritdoc cref="object.ToString"/>
     public override string ToString() => base.ToString();
 
+    /// <summary>
+    /// Creates a closed double interval (both start and end are included).
+    /// </summary>
+    /// <param name="start">The starting boundary.</param>
+    /// <param name="end">The ending boundary.</param>
+    /// <returns>A new <see cref="DoubleInterval"/> with both boundaries included.</returns>
     public new static DoubleInterval CreateClosed(double start, double end) => new(start, end, true, true);
 
+    /// <summary>
+    /// Creates an open double interval (neither start nor end are included).
+    /// </summary>
+    /// <param name="start">The starting boundary.</param>
+    /// <param name="end">The ending boundary.</param>
+    /// <returns>A new <see cref="DoubleInterval"/> with neither boundary included.</returns>
     public new static DoubleInterval CreateOpen(double start, double end) => new(start, end, false, false);
 
+    /// <summary>
+    /// Creates a double interval representing a single point (start and end are the same and included).
+    /// </summary>
+    /// <param name="boundary">The boundary value for the point.</param>
+    /// <returns>A new <see cref="DoubleInterval"/> representing a single point.</returns>
     public new static DoubleInterval CreatePoint(double boundary) => CreateClosed(boundary, boundary);
 }

--- a/Marsop.Ephemeral/Numerics/DoubleStandardLengthOperator.cs
+++ b/Marsop.Ephemeral/Numerics/DoubleStandardLengthOperator.cs
@@ -2,11 +2,17 @@ using Marsop.Ephemeral.Core;
 
 namespace Marsop.Ephemeral.Numerics;
 
+/// <summary>
+/// Provides a default length operator for intervals with <see cref="double"/> boundaries and lengths.
+/// </summary>
 public sealed class DoubleDefaultLengthOperator :
     ILengthOperator<double, double>
 {
     private static readonly DoubleDefaultLengthOperator _instance = new();
 
+    /// <summary>
+    /// Gets the singleton instance of the <see cref="DoubleDefaultLengthOperator"/>.
+    /// </summary>
     public static ILengthOperator<double, double> Instance => _instance;
 
     private DoubleDefaultLengthOperator()
@@ -14,9 +20,12 @@ public sealed class DoubleDefaultLengthOperator :
         // Private constructor to prevent external instantiation and enforce the singleton pattern.
     }
 
+    /// <inheritdoc/>
     public double Apply(double boundary, double length) => boundary + length;
 
+    /// <inheritdoc/>
     public double Measure(IBasicInterval<double> interval) => interval.End - interval.Start;
 
+    /// <inheritdoc/>
     public double Zero() => 0.0;
 }

--- a/Marsop.Ephemeral/Numerics/IntInterval.cs
+++ b/Marsop.Ephemeral/Numerics/IntInterval.cs
@@ -2,22 +2,50 @@ using Marsop.Ephemeral.Core;
 
 namespace Marsop.Ephemeral.Numerics;
 
+/// <summary>
+/// Represents an interval of <see cref="int"/> values.
+/// </summary>
 public record IntInterval :
     FullInterval<int, int>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IntInterval"/> class.
+    /// </summary>
+    /// <param name="start">The starting boundary of the interval.</param>
+    /// <param name="end">The ending boundary of the interval.</param>
+    /// <param name="startIncluded">A flag indicating whether the starting point is included. Defaults to true.</param>
+    /// <param name="endIncluded">A flag indicating whether the ending point is included. Defaults to true.</param>
     public IntInterval(int start, int end, bool startIncluded = true, bool endIncluded = true)
         : base(start, end, startIncluded, endIncluded)
     {
     }
 
+    /// <inheritdoc/>
     public override ILengthOperator<int, int> Operator => IntDefaultLengthOperator.Instance;
 
+    /// <inheritdoc cref="object.ToString"/>
     public override string ToString() => base.ToString();
 
+    /// <summary>
+    /// Creates a closed int interval (both start and end are included).
+    /// </summary>
+    /// <param name="start">The starting boundary.</param>
+    /// <param name="end">The ending boundary.</param>
+    /// <returns>A new <see cref="IntInterval"/> with both boundaries included.</returns>
     public new static IntInterval CreateClosed(int start, int end) => new(start, end, true, true);
 
+    /// <summary>
+    /// Creates an open int interval (neither start nor end are included).
+    /// </summary>
+    /// <param name="start">The starting boundary.</param>
+    /// <param name="end">The ending boundary.</param>
+    /// <returns>A new <see cref="IntInterval"/> with neither boundary included.</returns>
     public new static IntInterval CreateOpen(int start, int end) => new(start, end, false, false);
 
+    /// <summary>
+    /// Creates an int interval representing a single point (start and end are the same and included).
+    /// </summary>
+    /// <param name="boundary">The boundary value for the point.</param>
+    /// <returns>A new <see cref="IntInterval"/> representing a single point.</returns>
     public new static IntInterval CreatePoint(int boundary) => CreateClosed(boundary, boundary);
-
 }

--- a/Marsop.Ephemeral/Numerics/IntStandardLengthOperator.cs
+++ b/Marsop.Ephemeral/Numerics/IntStandardLengthOperator.cs
@@ -2,11 +2,17 @@ using Marsop.Ephemeral.Core;
 
 namespace Marsop.Ephemeral.Numerics;
 
+/// <summary>
+/// Provides a default length operator for intervals with <see cref="int"/> boundaries and lengths.
+/// </summary>
 public sealed class IntDefaultLengthOperator :
     ILengthOperator<int, int>
 {
     private static readonly IntDefaultLengthOperator _instance = new();
 
+    /// <summary>
+    /// Gets the singleton instance of the <see cref="IntDefaultLengthOperator"/>.
+    /// </summary>
     public static ILengthOperator<int, int> Instance => _instance;
 
     private IntDefaultLengthOperator()
@@ -14,9 +20,12 @@ public sealed class IntDefaultLengthOperator :
         // Private constructor to prevent external instantiation and enforce the singleton pattern.
     }
 
+    /// <inheritdoc/>
     public int Apply(int boundary, int length) => boundary + length;
 
+    /// <inheritdoc/>
     public int Measure(IBasicInterval<int> interval) => interval.End - interval.Start;
 
+    /// <inheritdoc/>
     public int Zero() => 0;
 }

--- a/Marsop.Ephemeral/Temporal/DateTimeOffsetInterval.cs
+++ b/Marsop.Ephemeral/Temporal/DateTimeOffsetInterval.cs
@@ -7,6 +7,9 @@ using Marsop.Ephemeral.Core;
 
 namespace Marsop.Ephemeral.Temporal;
 
+/// <summary>
+/// Represents a temporal interval defined by <see cref="DateTimeOffset"/> boundaries and measured with <see cref="TimeSpan"/>.
+/// </summary>
 public record DateTimeOffsetInterval :
     FullInterval<DateTimeOffset, TimeSpan>
 {
@@ -22,19 +25,45 @@ public record DateTimeOffsetInterval :
     {
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DateTimeOffsetInterval" /> class.
+    /// </summary>
+    /// <param name="start">The starting boundary.</param>
+    /// <param name="end">The ending boundary.</param>
+    /// <param name="startIncluded">A flag indicating whether the starting point is included.</param>
+    /// <param name="endIncluded">A flag indicating whether the ending point is included.</param>
     public DateTimeOffsetInterval(DateTimeOffset start, DateTimeOffset end, bool startIncluded, bool endIncluded) :
         base(start, end, startIncluded, endIncluded)
     {
     }
 
+    /// <inheritdoc/>
     public override ILengthOperator<DateTimeOffset, TimeSpan> Operator =>
         DateTimeOffsetTimeSpanLengthOperator.Instance;
 
+    /// <inheritdoc cref="object.ToString"/>
     public override string ToString() => base.ToString();
 
+    /// <summary>
+    /// Creates a closed date-time offset interval (both start and end are included).
+    /// </summary>
+    /// <param name="start">The starting boundary.</param>
+    /// <param name="end">The ending boundary.</param>
+    /// <returns>A new <see cref="DateTimeOffsetInterval"/> with both boundaries included.</returns>
     public new static DateTimeOffsetInterval CreateClosed(DateTimeOffset start, DateTimeOffset end) => new(start, end, true, true);
 
+    /// <summary>
+    /// Creates an open date-time offset interval (neither start nor end are included).
+    /// </summary>
+    /// <param name="start">The starting boundary.</param>
+    /// <param name="end">The ending boundary.</param>
+    /// <returns>A new <see cref="DateTimeOffsetInterval"/> with neither boundary included.</returns>
     public new static DateTimeOffsetInterval CreateOpen(DateTimeOffset start, DateTimeOffset end) => new(start, end, false, false);
 
+    /// <summary>
+    /// Creates a date-time offset interval representing a single point (start and end are the same and included).
+    /// </summary>
+    /// <param name="boundary">The boundary value for the point.</param>
+    /// <returns>A new <see cref="DateTimeOffsetInterval"/> representing a single point.</returns>
     public new static DateTimeOffsetInterval CreatePoint(DateTimeOffset boundary) => CreateClosed(boundary, boundary);
 }

--- a/Marsop.Ephemeral/Temporal/DateTimeOffsetStandardLengthOperator.cs
+++ b/Marsop.Ephemeral/Temporal/DateTimeOffsetStandardLengthOperator.cs
@@ -3,11 +3,17 @@ using Marsop.Ephemeral.Core;
 
 namespace Marsop.Ephemeral.Temporal;
 
+/// <summary>
+/// Provides a length operator for intervals with <see cref="DateTimeOffset"/> boundaries measured by <see cref="TimeSpan"/>.
+/// </summary>
 public sealed class DateTimeOffsetTimeSpanLengthOperator :
     ILengthOperator<DateTimeOffset, TimeSpan>
 {
     private static readonly DateTimeOffsetTimeSpanLengthOperator _instance = new();
 
+    /// <summary>
+    /// Gets the singleton instance of the <see cref="DateTimeOffsetTimeSpanLengthOperator"/>.
+    /// </summary>
     public static ILengthOperator<DateTimeOffset, TimeSpan> Instance => _instance;
 
     private DateTimeOffsetTimeSpanLengthOperator()
@@ -15,9 +21,12 @@ public sealed class DateTimeOffsetTimeSpanLengthOperator :
         // Private constructor to prevent external instantiation and enforce the singleton pattern.
     }
 
+    /// <inheritdoc/>
     public DateTimeOffset Apply(DateTimeOffset boundary, TimeSpan length) => boundary.Add(length);
 
+    /// <inheritdoc/>
     public TimeSpan Measure(IBasicInterval<DateTimeOffset> interval) => interval.End - interval.Start;
 
+    /// <inheritdoc/>
     public TimeSpan Zero() => TimeSpan.Zero;
 }

--- a/docs/changes-v1.md
+++ b/docs/changes-v1.md
@@ -1,12 +1,9 @@
 # Changelog
 
-## Version 0.2.0
+## Version 0.2.x
 
 - Added XML documentation for all types and public members in `Marsop.Ephemeral` and `Marsop.Ephemeral.Net6`.
 - Enabled generation of XML documentation files.
-
-## Version 1.x
-
 - New "base" classes `BasicInterval` and `FullInterval` introducing generics.
 - Utility classes have been included to help migrating: `DateTimeOffsetInterval`, `IntInterval`, `DoubleInterval`.
 - `Duration()` is now called `Length()` and it is an extension method.
@@ -14,6 +11,6 @@
 - `Interval` has been renamed or replaced by specialized utilities.
 - `AggregatedDuration` is no longer supported in DisjointedSets.
 
-## Version 0.x
+## Version 0.1.x
 
 - Inclusion of `DisjointIntervalSet` to collect intervals without overlaps.

--- a/docs/changes-v1.md
+++ b/docs/changes-v1.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 0.3.0
+## Version 0.2.0
 
 - Added XML documentation for all types and public members in `Marsop.Ephemeral` and `Marsop.Ephemeral.Net6`.
 - Enabled generation of XML documentation files.

--- a/docs/changes-v1.md
+++ b/docs/changes-v1.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 0.3.0
+
+- Added XML documentation for all types and public members in `Marsop.Ephemeral` and `Marsop.Ephemeral.Net6`.
+- Enabled generation of XML documentation files.
+
 ## Version 1.x
 
 - New "base" classes `BasicInterval` and `FullInterval` introducing generics.


### PR DESCRIPTION
Adds XML documentation to numerics and temporal namespaces to begin fulfilling requirements. Note this is only a partial fix and there are still remaining members missing documentation, which need to be resolved.

---
*PR created automatically by Jules for task [9637009566695063436](https://jules.google.com/task/9637009566695063436) started by @marsop*