### PR TITLE
🧪 Missing edge case tests for IsBetweenBothIncluded

### DIFF
--- a/Marsop.Ephemeral.Tests/Core/Extensions/ComparableExtensionsTests.cs
+++ b/Marsop.Ephemeral.Tests/Core/Extensions/ComparableExtensionsTests.cs
@@ -1,0 +1,45 @@
+using System;
+using FluentAssertions;
+using Marsop.Ephemeral.Core;
+using Xunit;
+
+namespace Marsop.Ephemeral.Tests.Core.Extensions;
+
+public class ComparableExtensionsTests
+{
+    [Fact]
+    public void IsBetweenBothIncluded_WhenMaxIsLessThanMin_ThrowsArgumentOutOfRangeException()
+    {
+        int min = 10;
+        int max = 5;
+        int current = 7;
+
+        Action act = () => current.IsBetweenBothIncluded(min, max);
+
+        act.Should().Throw<ArgumentOutOfRangeException>().WithParameterName("max");
+    }
+
+    [Theory]
+    [InlineData(5, 1, 10)] // Current is between min and max
+    [InlineData(1, 1, 10)] // Current is equal to min
+    [InlineData(10, 1, 10)] // Current is equal to max
+    [InlineData(5, 5, 5)] // Min equals max and current equals them
+    public void IsBetweenBothIncluded_WhenCurrentIsWithinBoundaries_ReturnsTrue(int current, int min, int max)
+    {
+        bool result = current.IsBetweenBothIncluded(min, max);
+
+        result.Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(0, 1, 10)] // Current is less than min
+    [InlineData(11, 1, 10)] // Current is greater than max
+    [InlineData(4, 5, 5)] // Min equals max and current is less
+    [InlineData(6, 5, 5)] // Min equals max and current is greater
+    public void IsBetweenBothIncluded_WhenCurrentIsOutsideBoundaries_ReturnsFalse(int current, int min, int max)
+    {
+        bool result = current.IsBetweenBothIncluded(min, max);
+
+        result.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added missing tests for the `IsBetweenBothIncluded` method in `ComparableExtensions` to ensure all edge cases and boundaries are correctly handled.

📊 **Coverage:** Covered the following scenarios:
* `ArgumentOutOfRangeException` thrown when max is less than min.
* Values completely within the boundaries.
* Values on the exact lower and upper boundaries (`current == min` and `current == max`).
* Compressed boundaries where `min == max == current`.
* Values outside the boundaries (less than min or greater than max).

✨ **Result:** Improved test reliability and explicit documentation of expected boundary behavior via tests.

---
*PR created automatically by Jules for task [10710483131093935369](https://jules.google.com/task/10710483131093935369) started by @marsop*