### PR TITLE
🧪 [testing improvement] Add missing test for ArgumentOutOfRangeException in IsBetweenBothIncluded

### DIFF
--- a/Marsop.Ephemeral.Tests/Core/Extensions/ComparableExtensionsTests.cs
+++ b/Marsop.Ephemeral.Tests/Core/Extensions/ComparableExtensionsTests.cs
@@ -1,0 +1,25 @@
+using System;
+using FluentAssertions;
+using Marsop.Ephemeral.Core;
+using Xunit;
+
+namespace Marsop.Ephemeral.Tests.Core.Extensions;
+
+public class ComparableExtensionsTests
+{
+    [Fact]
+    public void IsBetweenBothIncluded_MaxLessThanMin_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        int current = 5;
+        int min = 10;
+        int max = 0;
+
+        // Act
+        Action act = () => current.IsBetweenBothIncluded(min, max);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithParameterName("max");
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added a missing unit test to cover the `ArgumentOutOfRangeException` error path in `ComparableExtensions.IsBetweenBothIncluded` when the max parameter is less than the min parameter.
📊 **Coverage:** The scenario where `max < min` in `IsBetweenBothIncluded` is now explicitly tested.
✨ **Result:** Increased code coverage and confidence that edge cases with pure functions are correctly handled by throwing the proper exception.

---
*PR created automatically by Jules for task [14198652113388462769](https://jules.google.com/task/14198652113388462769) started by @marsop*