### PR TITLE
🧪 Add tests for FullIntervalExtensions.Shift method

### DIFF
--- a/Marsop.Ephemeral.Tests/Core/Extensions/FullIntervalExtensionsTests.cs
+++ b/Marsop.Ephemeral.Tests/Core/Extensions/FullIntervalExtensionsTests.cs
@@ -1,0 +1,76 @@
+using System;
+using FluentAssertions;
+using Marsop.Ephemeral.Core;
+using Xunit;
+
+namespace Marsop.Ephemeral.Tests.Core.Extensions;
+
+public class FullIntervalExtensionsTests
+{
+    private class TestLengthOperator : ILengthOperator<int, int>
+    {
+        public static readonly TestLengthOperator Instance = new();
+
+        public int Apply(int boundary, int length) => boundary + length;
+
+        public int Measure(IBasicInterval<int> interval) => interval.End - interval.Start;
+
+        public int Zero() => 0;
+    }
+
+    private record TestFullInterval : FullInterval<int, int>
+    {
+        public TestFullInterval(int start, int end, bool startIncluded, bool endIncluded)
+            : base(start, end, startIncluded, endIncluded)
+        {
+        }
+
+        public override ILengthOperator<int, int> Operator => TestLengthOperator.Instance;
+
+        public sealed override string ToString() => base.ToString();
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public void Shift_PositiveOffset_ShouldShiftBoundsAndMaintainMeasure(bool startIncluded, bool endIncluded)
+    {
+        // Arrange
+        var interval = new TestFullInterval(5, 10, startIncluded, endIncluded);
+        int offset = 3;
+
+        // Act
+        var result = interval.Shift(offset);
+
+        // Assert
+        result.Start.Should().Be(8);
+        result.End.Should().Be(13);
+        result.StartIncluded.Should().Be(startIncluded);
+        result.EndIncluded.Should().Be(endIncluded);
+        result.DefaultMeasure().Should().Be(5);
+    }
+
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    public void Shift_NegativeOffset_ShouldShiftBoundsAndMaintainMeasure(bool startIncluded, bool endIncluded)
+    {
+        // Arrange
+        var interval = new TestFullInterval(5, 10, startIncluded, endIncluded);
+        int offset = -2;
+
+        // Act
+        var result = interval.Shift(offset);
+
+        // Assert
+        result.Start.Should().Be(3);
+        result.End.Should().Be(8);
+        result.StartIncluded.Should().Be(startIncluded);
+        result.EndIncluded.Should().Be(endIncluded);
+        result.DefaultMeasure().Should().Be(5);
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: The `Shift` extension method for `FullInterval` was entirely untested. This PR adds tests covering both positive and negative offsets, ensuring all inclusivity combinations are verified correctly.

📊 **Coverage:** What scenarios are now tested:
- Positive shift operations (`Shift_PositiveOffset_ShouldShiftBoundsAndMaintainMeasure`)
- Negative shift operations (`Shift_NegativeOffset_ShouldShiftBoundsAndMaintainMeasure`)
- Tests are parameterized using xUnit `[Theory]` to exhaustively cover combinations of `StartIncluded` and `EndIncluded` (both true/false).

✨ **Result:** The improvement in test coverage: A new test file `FullIntervalExtensionsTests.cs` has been added, significantly improving confidence in the correctness of interval shifting. The overall core domain test coverage is increased.

---
*PR created automatically by Jules for task [6324846712213328082](https://jules.google.com/task/6324846712213328082) started by @marsop*