### PR TITLE
🧪 Untested ArgumentOutOfRangeException in IsBetweenMaxIncluded

### DIFF
--- a/Marsop.Ephemeral.Tests/Core/Extensions/ComparableExtensionsTests.cs
+++ b/Marsop.Ephemeral.Tests/Core/Extensions/ComparableExtensionsTests.cs
@@ -1,0 +1,24 @@
+using System;
+using FluentAssertions;
+using Marsop.Ephemeral.Core;
+using Xunit;
+
+namespace Marsop.Ephemeral.Tests.Core.Extensions;
+
+public class ComparableExtensionsTests
+{
+    [Fact]
+    public void IsBetweenMaxIncluded_MaxLessThanMin_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        var current = 5;
+        var min = 10;
+        var max = 0;
+
+        // Act
+        Action act = () => current.IsBetweenMaxIncluded(min, max);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>().WithParameterName("max");
+    }
+}


### PR DESCRIPTION
🎯 **What:** The untested ArgumentOutOfRangeException error path in ComparableExtensions.IsBetweenMaxIncluded.
📊 **Coverage:** The scenario where max is less than min is now covered.
✨ **Result:** Increased test coverage and confidence in edge case handling.

---
*PR created automatically by Jules for task [8737610115853301975](https://jules.google.com/task/8737610115853301975) started by @marsop*