### PR TITLE
🧪 add unit tests for IsBetweenMaxIncluded edge cases

### DIFF
--- a/Marsop.Ephemeral.Tests/Core/Extensions/ComparableExtensionsTests.cs
+++ b/Marsop.Ephemeral.Tests/Core/Extensions/ComparableExtensionsTests.cs
@@ -1,0 +1,41 @@
+using System;
+using FluentAssertions;
+using Marsop.Ephemeral.Core;
+using Xunit;
+
+namespace Marsop.Ephemeral.Tests.Core.Extensions;
+
+public class ComparableExtensionsTests
+{
+    [Theory]
+    [InlineData(5, 0, 10, true)]   // current is exactly between min and max
+    [InlineData(0, 0, 10, false)]  // current == min
+    [InlineData(10, 0, 10, true)]  // current == max
+    [InlineData(-1, 0, 10, false)] // current < min
+    [InlineData(11, 0, 10, false)] // current > max
+    [InlineData(5, 5, 5, false)]   // min == max, current == min == max
+    public void IsBetweenMaxIncluded_WithVariousBoundaries_ReturnsExpectedResult(int current, int min, int max, bool expectedResult)
+    {
+        // Act
+        bool result = current.IsBetweenMaxIncluded(min, max);
+
+        // Assert
+        result.Should().Be(expectedResult);
+    }
+
+    [Fact]
+    public void IsBetweenMaxIncluded_MaxLessThanMin_ThrowsArgumentOutOfRangeException()
+    {
+        // Arrange
+        int current = 5;
+        int min = 10;
+        int max = 0;
+
+        // Act
+        Action act = () => current.IsBetweenMaxIncluded(min, max);
+
+        // Assert
+        act.Should().Throw<ArgumentOutOfRangeException>()
+            .WithMessage("*max*");
+    }
+}


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was missing edge case tests for the `IsBetweenMaxIncluded` extension method.
📊 **Coverage:** The scenarios now tested are:
  - Valid scenario where `current` lies within the `min` and `max`.
  - Edge cases strictly hitting the excluded `min` boundary, strictly hitting the included `max` boundary.
  - Out of bounds conditions (`current < min` and `current > max`).
  - Argument exceptions triggered when the boundaries are logically crossed (`max < min`).
✨ **Result:** Enhanced test coverage for numerical checking constraints which should provide better code safety metrics to catch regressions when updating mathematical rules of operation later.

---
*PR created automatically by Jules for task [6291576909460509274](https://jules.google.com/task/6291576909460509274) started by @marsop*