### PR TITLE
🧪 Add tests for FullIntervalExtensions.ToIntervalSet

### DIFF
--- a/Marsop.Ephemeral.Tests/Core/Extensions/FullIntervalExtensionsTests.cs
+++ b/Marsop.Ephemeral.Tests/Core/Extensions/FullIntervalExtensionsTests.cs
@@ -1,0 +1,48 @@
+using System;
+using FluentAssertions;
+using Marsop.Ephemeral.Core;
+using Xunit;
+
+namespace Marsop.Ephemeral.Tests.Core.Extensions;
+
+public class FullIntervalExtensionsTests
+{
+    private class TestLengthOperator : ILengthOperator<int, int>
+    {
+        public static readonly TestLengthOperator Instance = new();
+
+        public int Apply(int boundary, int length) => boundary + length;
+
+        public int Measure(IBasicInterval<int> interval) => interval.End - interval.Start;
+
+        public int Zero() => 0;
+    }
+
+    private record TestFullInterval : FullInterval<int, int>
+    {
+        public TestFullInterval(int start, int end, bool startIncluded, bool endIncluded)
+            : base(start, end, startIncluded, endIncluded)
+        {
+        }
+
+        public override ILengthOperator<int, int> Operator => TestLengthOperator.Instance;
+    }
+
+    [Fact]
+    public void ToIntervalSet_ValidInterval_ReturnsDisjointIntervalSetContainingInterval()
+    {
+        // Arrange
+        var start = 5;
+        var end = 10;
+        var interval = new TestFullInterval(start, end, true, false);
+
+        // Act
+        var result = interval.ToIntervalSet();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().HaveCount(1);
+        result[0].Should().BeSameAs(interval);
+        result.LengthOperator.Should().BeSameAs(interval.Operator);
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added tests for the untested `ToIntervalSet` public method in `Marsop.Ephemeral/Core/Extensions/FullIntervalExtensions.cs`.
📊 **Coverage:** Covered the happy path for `ToIntervalSet` using a mocked interval (`TestFullInterval`) and length operator. 
✨ **Result:** Improved test coverage and ensured correct behavior when a `FullInterval` is converted to a `DisjointIntervalSet`.

---
*PR created automatically by Jules for task [3928233833514117988](https://jules.google.com/task/3928233833514117988) started by @marsop*