### PR TITLE
🧹 Rename WithMeaure to WithMeasure

### DIFF
--- a/Marsop.Ephemeral/Core/Extensions/BasicIntervalExtensions.cs
+++ b/Marsop.Ephemeral/Core/Extensions/BasicIntervalExtensions.cs
@@ -22,7 +22,7 @@ public static class BasicIntervalExtensions
     }
 
 
-    public static BasicMeasuredInterval<TBoundary, TLength> WithMeaure<TBoundary, TLength>(
+    public static BasicMeasuredInterval<TBoundary, TLength> WithMeasure<TBoundary, TLength>(
         this IBasicInterval<TBoundary> interval,
         ICanMeasure<TBoundary, TLength> measurer)
         where TBoundary : notnull, IComparable<TBoundary>
@@ -365,7 +365,7 @@ public static class BasicIntervalExtensions
                     subtraction.Start,
                     source.StartIncluded,
                     !subtraction.StartIncluded)
-                .WithMeaure(lengthOperator)
+                .WithMeasure(lengthOperator)
             );
         if (source.End.IsGreaterThan(subtraction.End) ||
             source.End.IsEqualTo(subtraction.End) && source.EndIncluded && !subtraction.EndIncluded)
@@ -375,7 +375,7 @@ public static class BasicIntervalExtensions
                     source.End,
                     !subtraction.EndIncluded,
                     source.EndIncluded)
-                .WithMeaure(lengthOperator));
+                .WithMeasure(lengthOperator));
 
         return result;
     }

--- a/Marsop.Ephemeral/Core/Extensions/FullIntervalExtensions.cs
+++ b/Marsop.Ephemeral/Core/Extensions/FullIntervalExtensions.cs
@@ -26,7 +26,7 @@ public static class FullIntervalExtensions
     {
         return BasicIntervalExtensions
             .Shift(interval, offset, interval.Operator)
-            .WithMeaure(interval.Operator);
+            .WithMeasure(interval.Operator);
     }
 
     public static BasicMeasuredInterval<TBoundary, TLength> ShiftStart<TBoundary, TLength>(
@@ -36,7 +36,7 @@ public static class FullIntervalExtensions
     {
         return BasicIntervalExtensions
             .ShiftStart(interval, offset, interval.Operator)
-            .WithMeaure(interval.Operator);
+            .WithMeasure(interval.Operator);
     }
 
     public static BasicMeasuredInterval<TBoundary, TLength> ShiftEnd<TBoundary, TLength>(
@@ -46,7 +46,7 @@ public static class FullIntervalExtensions
     {
         return BasicIntervalExtensions
             .ShiftEnd(interval, offset, interval.Operator)
-            .WithMeaure(interval.Operator);
+            .WithMeasure(interval.Operator);
     }
 
     public static TLength LengthOfIntersect<TBoundary, TLength>(

--- a/Marsop.Ephemeral/Core/Extensions/IntervalSetExtensions.cs
+++ b/Marsop.Ephemeral/Core/Extensions/IntervalSetExtensions.cs
@@ -43,7 +43,7 @@ public static class IntervalSetExtensions
                             item.End,
                             cachedItem.StartIncluded,
                             item.EndIncluded)
-                            .WithMeaure(set.LengthOperator);
+                            .WithMeasure(set.LengthOperator);
                     }
                     else
                     {
@@ -101,7 +101,7 @@ public static class IntervalSetExtensions
         var intersections = set
             .Select(x => x.Intersect(interval))
             .Values()
-            .Select(x => x.WithMeaure(set.LengthOperator))
+            .Select(x => x.WithMeasure(set.LengthOperator))
             .ToList();
         return new DisjointIntervalSet<TBoundary, TLength>(set.LengthOperator, intersections);
     }
@@ -137,7 +137,7 @@ public static class IntervalSetExtensions
         where TBoundary : notnull, IComparable<TBoundary>
     {
         return new BasicInterval<TBoundary>(s.Start, s.End, s.Covers(s.Start), s.Covers(s.End))
-            .WithMeaure(s.LengthOperator);
+            .WithMeasure(s.LengthOperator);
     }
 
     /// <summary>
@@ -160,7 +160,7 @@ public static class IntervalSetExtensions
         var newInterval = interval;
         foreach (var overlap in overlaps)
         {
-            newInterval = newInterval.Join(overlap).WithMeaure(set.LengthOperator);
+            newInterval = newInterval.Join(overlap).WithMeasure(set.LengthOperator);
         }
 
         result.Add(newInterval);

--- a/docs/methods.md
+++ b/docs/methods.md
@@ -16,7 +16,7 @@ The following methods are implemented as extension methods to be able to use the
 ## Methods available from `IBasicInterval<TBoundary>`
 
 - `Measure(measurer: ILengthOperator<TBoundary, TLength>): TLength`
-- `WithMeaure(measurer: ILengthOperator<TBoundary, TLength>): BasicMeasuredInterval<TBoundary, TLength>`
+- `WithMeasure(measurer: ILengthOperator<TBoundary, TLength>): BasicMeasuredInterval<TBoundary, TLength>`
 - `IsEquivalentIntervalTo(i: IBasicInterval<TBoundary>) : bool`
 - `Covers(t: TBoundary) : bool`
 - `Covers(i: IBasicInterval<TBoundary>) : bool`


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is a simple typo in a method name: `WithMeaure` -> `WithMeasure`.
💡 **Why:** This improves readability and maintainability by using the correct terminology.
✅ **Verification:** Verified by checking usages across the codebase and confirming no compilation errors or test failures were introduced.
✨ **Result:** The codebase now has the correct spelling for `WithMeasure`, ensuring clear API names.

---
*PR created automatically by Jules for task [10893204083747696135](https://jules.google.com/task/10893204083747696135) started by @marsop*