### PR TITLE
🧪 [testing improvement] Add tests and null checks for BasicIntervalExtensions.Covers

### DIFF
--- a/Marsop.Ephemeral.Tests/Core/Extensions/BasicIntervalExtensionsTests.cs
+++ b/Marsop.Ephemeral.Tests/Core/Extensions/BasicIntervalExtensionsTests.cs
@@ -1,0 +1,104 @@
+using System;
+using FluentAssertions;
+using Marsop.Ephemeral.Core;
+using Xunit;
+
+namespace Marsop.Ephemeral.Tests.Core.Extensions;
+
+public class BasicIntervalExtensionsTests
+{
+    private record TestBasicInterval : BasicInterval<int>
+    {
+        public TestBasicInterval(int start, int end, bool startIncluded, bool endIncluded)
+            : base(start, end, startIncluded, endIncluded)
+        {
+        }
+    }
+
+    [Fact]
+    public void Covers_Boundary_NullInterval_ThrowsArgumentNullException()
+    {
+        // Arrange
+        IBasicInterval<int> interval = null!;
+
+        // Act
+        Action action = () => interval.Covers(5);
+
+        // Assert
+        action.Should().Throw<ArgumentNullException>().WithParameterName("interval");
+    }
+
+    [Theory]
+    [InlineData(4)]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void Covers_Boundary_LessThanStart_ReturnsFalse(int boundary)
+    {
+        // Arrange
+        var interval = new TestBasicInterval(5, 10, true, true);
+
+        // Act
+        var result = interval.Covers(boundary);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(11)]
+    [InlineData(20)]
+    public void Covers_Boundary_GreaterThanEnd_ReturnsFalse(int boundary)
+    {
+        // Arrange
+        var interval = new TestBasicInterval(5, 10, true, true);
+
+        // Act
+        var result = interval.Covers(boundary);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Covers_Boundary_EqualToStart_NotIncluded_ReturnsFalse()
+    {
+        // Arrange
+        var interval = new TestBasicInterval(5, 10, false, true);
+
+        // Act
+        var result = interval.Covers(5);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Covers_Boundary_EqualToEnd_NotIncluded_ReturnsFalse()
+    {
+        // Arrange
+        var interval = new TestBasicInterval(5, 10, true, false);
+
+        // Act
+        var result = interval.Covers(10);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(5, true, true)]
+    [InlineData(10, true, true)]
+    [InlineData(7, true, true)]
+    [InlineData(7, false, false)]
+    public void Covers_Boundary_InsideInterval_ReturnsTrue(int boundary, bool startIncluded, bool endIncluded)
+    {
+        // Arrange
+        var interval = new TestBasicInterval(5, 10, startIncluded, endIncluded);
+
+        // Act
+        var result = interval.Covers(boundary);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+}

--- a/Marsop.Ephemeral/Core/Extensions/BasicIntervalExtensions.cs
+++ b/Marsop.Ephemeral/Core/Extensions/BasicIntervalExtensions.cs
@@ -72,6 +72,8 @@ public static class BasicIntervalExtensions
         TBoundary boundary)
         where TBoundary : notnull, IComparable<TBoundary>
     {
+        if (interval is null) throw new ArgumentNullException(nameof(interval));
+
         if (boundary.IsLessThan(interval.Start))
         {
             return false;


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `BasicIntervalExtensions.Covers` method was missing a null check for the `interval` argument, which would result in a generic `NullReferenceException` instead of an explicit `ArgumentNullException`. Additionally, tests for the method were completely absent.

📊 **Coverage:** What scenarios are now tested
- Throwing `ArgumentNullException` when `interval` is null.
- Handling boundaries strictly lower than the start bound.
- Handling boundaries strictly higher than the end bound.
- Handling boundaries equal to the start/end bound, varying the inclusive/exclusive states.
- Handling boundaries clearly inside the interval.

✨ **Result:** The improvement in test coverage
The `Covers` extension method is fully tested, protecting it from regressions in future refactoring. Explicit null-validation provides clearer error messages for callers.

---
*PR created automatically by Jules for task [9538170040587315956](https://jules.google.com/task/9538170040587315956) started by @marsop*