### PR TITLE
🔒 Pin GitHub Actions dependencies to commit SHAs to prevent supply chain attacks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,6 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Deploy docs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        uses: mhausenblas/mkdocs-deploy-gh-pages@a31c6b13a80e4a4fbb525eeb7a2a78253bb15fa5
         env:
           GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}


### PR DESCRIPTION
🎯 **What:** Replaced the mutable `@master` tag with a static commit SHA (`a31c6b13a80e4a4fbb525eeb7a2a78253bb15fa5`) for the `mhausenblas/mkdocs-deploy-gh-pages` action in the GitHub Actions workflow.
⚠️ **Risk:** Using mutable tags for third-party GitHub Actions exposes the repository to potential supply chain attacks. If the action's repository is compromised or maliciously updated, the workflow would automatically pull in the changes, potentially leading to unauthorized access or code execution.
🛡️ **Solution:** Pinned the dependency to a specific, immutable commit SHA. This ensures that the workflow always uses the exact, verified version of the action, mitigating the risk of unexpected or malicious changes being pulled in.

---
*PR created automatically by Jules for task [12269439623378860988](https://jules.google.com/task/12269439623378860988) started by @marsop*