### PR TITLE
🧪 Add test for disjoint intervals in Intersect

### DIFF
--- a/Marsop.Ephemeral.Tests/Core/Extensions/BasicIntervalExtensionsTests.cs
+++ b/Marsop.Ephemeral.Tests/Core/Extensions/BasicIntervalExtensionsTests.cs
@@ -101,4 +101,18 @@ public class BasicIntervalExtensionsTests
         // Assert
         result.Should().BeTrue();
     }
+
+    [Fact]
+    public void Intersect_DisjointIntervals_ReturnsNone()
+    {
+        // Arrange
+        var first = new TestBasicInterval(1, 2, true, true);
+        var second = new TestBasicInterval(3, 4, true, true);
+
+        // Act
+        var result = first.Intersect(second);
+
+        // Assert
+        result.HasValue.Should().BeFalse();
+    }
 }


### PR DESCRIPTION
🎯 **What:** The testing gap addressed for testing that `Intersect` returns `Option.None` for disjoint intervals.
📊 **Coverage:** Intersect method error conditions.
✨ **Result:** Test coverage is improved.

---
*PR created automatically by Jules for task [18443104561419255044](https://jules.google.com/task/18443104561419255044) started by @marsop*