### PR TITLE
📝 [add double interval example]

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,17 @@ var nextTen = IntInterval.CreateClosed(11, 20);
 firstTen.IsContiguouslyFollowedBy(nextTen); // returns false if both are closed.
 ```
 
+### Double Interval Example
+
+```csharp
+var range1 = DoubleInterval.CreateClosed(1.5, 4.5);
+var range2 = DoubleInterval.CreateOpen(3.0, 6.0);
+
+range1.Intersects(range2); // returns true
+range1.Covers(4.5); // returns true
+range2.Covers(3.0); // returns false (because it's open)
+```
+
 ### Interval Collection Example
 
 ```csharp


### PR DESCRIPTION
Added a new `Double Interval Example` to `docs/index.md` to demonstrate the usage of `DoubleInterval` from the library, including creating open/closed intervals and using the `Intersects` and `Covers` extension methods. This change improves documentation clarity by providing another concrete code snippet for numeric intervals.

---
*PR created automatically by Jules for task [8396730548506741519](https://jules.google.com/task/8396730548506741519) started by @marsop*