### PR TITLE
chore: promote version 0.2.0 to stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2024-03-21
+
+### Changed
+- Promoted 0.2.0 from pre-release (beta) to stable release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2024-03-21
+## [0.2.0] - 2025-06-02
+
+### Added
+- Generalized intervals beyond `DateTimeOffset` using `IBasicInterval<TBoundary>` and `BasicInterval<TBoundary>`.
+- Core generic interval interfaces and implementation.
+- .NET 6 targeted extensions and types (`DateOnlyInterval`, `TimeOnlyInterval`).
+- Polyglot notebooks for documentation (`notebooks/` directory).
+- Extensive new test suites for generic interval behaviors.
 
 ### Changed
 - Promoted 0.2.0 from pre-release (beta) to stable release.
+- Refactored `DateTimeOffsetInterval` to inherit from new generic classes.
+- Target frameworks updated across projects to include `net6.0` and `net10.0` for tests.
+- Replaced GroupBy and ToDictionary with a single pass loop in IntervalSetExtensions.Join to reduce heap allocations and execution time.
+
+## [0.1.10] - 2020-07-01
+
+### Added
+- Initial interval operations including overlapping, unions, and intersections on `DateTimeOffset` types.
+- DisjointIntervalSet implementation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extensive new test suites for generic interval behaviors.
 
 ### Changed
-- Promoted 0.2.0 from pre-release (beta) to stable release.
 - Refactored `DateTimeOffsetInterval` to inherit from new generic classes.
 - Target frameworks updated across projects to include `net6.0` and `net10.0` for tests.
 - Replaced GroupBy and ToDictionary with a single pass loop in IntervalSetExtensions.Join to reduce heap allocations and execution time.

--- a/Marsop.Ephemeral.Net6/Marsop.Ephemeral.Net6.csproj
+++ b/Marsop.Ephemeral.Net6/Marsop.Ephemeral.Net6.csproj
@@ -21,7 +21,7 @@
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     
-    <Version>$(VersionPrefix)-beta.7</Version>
+    <Version>$(VersionPrefix)</Version>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     

--- a/Marsop.Ephemeral.Tests/Marsop.Ephemeral.Tests.csproj
+++ b/Marsop.Ephemeral.Tests/Marsop.Ephemeral.Tests.csproj
@@ -2,10 +2,9 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <AssemblyVersion>0.1.8.0</AssemblyVersion>
-    <FileVersion>0.1.8.0</FileVersion>
-    <InformationalVersion>0.1.8+2.Branch.master.Sha.eba8d8fee421bfca5e09c231dba73383e21c06bd</InformationalVersion>
-    <Version>0.1.8</Version>
+    <AssemblyVersion>0.2.0.0</AssemblyVersion>
+    <FileVersion>0.2.0.0</FileVersion>
+    <Version>0.2.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild">

--- a/Marsop.Ephemeral/Marsop.Ephemeral.csproj
+++ b/Marsop.Ephemeral/Marsop.Ephemeral.csproj
@@ -21,7 +21,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-    <Version>$(VersionPrefix)-beta.7</Version>
+    <Version>$(VersionPrefix)</Version>
     <AssemblyVersion>$(VersionPrefix)</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     


### PR DESCRIPTION
Promoted the package to a stable 0.2.0 release by updating `<Version>` tags and ensuring tests correctly match versions across the solution. Initialized `CHANGELOG.md` per instructions.

---
*PR created automatically by Jules for task [10846082953316841640](https://jules.google.com/task/10846082953316841640) started by @marsop*