### PR TITLE
📝 Fix broken length operator class name in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ firstTen.IsContiguouslyFollowedBy(nextTen); // returns false if both are closed.
 ### Interval Collection Example
 
 ```csharp
-var lengthOperator = DateTimeOffsetStandardLengthOperator.Instance;
+var lengthOperator = DateTimeOffsetTimeSpanLengthOperator.Instance;
 var collection = new DisjointIntervalSet<DateTimeOffset, TimeSpan>(lengthOperator);
 collection.Add(yesterday);
 collection.Add(today);

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,7 +65,7 @@ range2.Covers(3.0); // returns false (because it's open)
 ### Interval Collection Example
 
 ```csharp
-var lengthOperator = DateTimeOffsetStandardLengthOperator.Instance;
+var lengthOperator = DateTimeOffsetTimeSpanLengthOperator.Instance;
 var collection = new DisjointIntervalSet<DateTimeOffset, TimeSpan>(lengthOperator);
 collection.Add(yesterday);
 collection.Add(today);


### PR DESCRIPTION
This PR fixes a broken code snippet in the documentation (`README.md` and `docs/index.md`) by replacing the non-existent `DateTimeOffsetStandardLengthOperator` class with the correct `DateTimeOffsetTimeSpanLengthOperator` class. This ensures the provided example code snippet is accurate and compilable. This fulfills the user's request to "Improve the documentation one item at a time" by addressing a specific inaccuracy.

---
*PR created automatically by Jules for task [5180936848798137335](https://jules.google.com/task/5180936848798137335) started by @marsop*